### PR TITLE
fix (graph.py): Fix input of wildcarded hostnames via file. Fixes #5.

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -32,7 +32,7 @@ many_host_sql = '''
 SELECT
   {cols}
 FROM host_index
-WHERE regexp_matches(surt_host_name, '{surt_list_regexp}'){and_tld}
+WHERE ({surt_like_clause_list}){and_tld}
 GROUP BY crawl
 ORDER BY crawl ASC
 '''
@@ -116,7 +116,7 @@ def surt_host_name_to_title(surt_host_name):
 def get_values(host_index, surt_host_name, col_names, verbose=0):
     if not isinstance(surt_host_name, str):
         # if not a string, it's a list of strings
-        surt_list_regexp = '^(' + '|'.join(surt.rstrip(',') + (',.*' if surt.endswith(',') else '') for surt in surt_host_name) + ')$'
+        surt_like_clause_list = ' OR '.join(f"surt_host_name LIKE '{surt + ('%' if surt.endswith(',') else '')}'" for surt in surt_host_name)
 
         tlds = set([s.split(',', 1)[0] for s in surt_host_name])
         if len(tlds) == 1:
@@ -127,7 +127,7 @@ def get_values(host_index, surt_host_name, col_names, verbose=0):
 
         cols = ', '.join(f'CAST(SUM({col}) AS INT64) AS sum_{col}' for col in col_names if col != 'crawl')
         cols = 'crawl, '+cols
-        sql = many_host_sql.format(cols=cols, surt_list_regexp=surt_list_regexp, and_tld=and_tld)
+        sql = many_host_sql.format(cols=cols, surt_like_clause_list=surt_like_clause_list, and_tld=and_tld)
         if verbose:
             print(sql)
         return duckdb.sql(sql).fetch_arrow_table()

--- a/graph.py
+++ b/graph.py
@@ -32,7 +32,7 @@ many_host_sql = '''
 SELECT
   {cols}
 FROM host_index
-WHERE contains(ARRAY [{surt_list}], surt_host_name){and_tld}
+WHERE regexp_matches(surt_host_name, '{surt_list_regexp}'){and_tld}
 GROUP BY crawl
 ORDER BY crawl ASC
 '''
@@ -116,7 +116,7 @@ def surt_host_name_to_title(surt_host_name):
 def get_values(host_index, surt_host_name, col_names, verbose=0):
     if not isinstance(surt_host_name, str):
         # if not a string, it's a list of strings
-        surt_list = ','.join(f"'{s}'" for s in surt_host_name)
+        surt_list_regexp = '^(' + '|'.join(surt.rstrip(',') + (',.*' if surt.endswith(',') else '') for surt in surt_host_name) + ')$'
 
         tlds = set([s.split(',', 1)[0] for s in surt_host_name])
         if len(tlds) == 1:
@@ -127,7 +127,7 @@ def get_values(host_index, surt_host_name, col_names, verbose=0):
 
         cols = ', '.join(f'CAST(SUM({col}) AS INT64) AS sum_{col}' for col in col_names if col != 'crawl')
         cols = 'crawl, '+cols
-        sql = many_host_sql.format(cols=cols, surt_list=surt_list, and_tld=and_tld)
+        sql = many_host_sql.format(cols=cols, surt_list_regexp=surt_list_regexp, and_tld=and_tld)
         if verbose:
             print(sql)
         return duckdb.sql(sql).fetch_arrow_table()


### PR DESCRIPTION
Fixes https://github.com/commoncrawl/cc-host-index/issues/5

This PR:
- [x] Expands surt inputs from file to a LIKE-clause list in `many_host_sql` template
    - `many_host_sql`  is used only when surts come from an input file - so this change affects only input file argument route.
    - An alternative was to use a function like `regexp_matches` (for duckdb) instead of a list of LIKE clauses, but thats engine dependent. Might be preferred if the code will always be used only with duckdb?
- [x] Adds `%` to surt inputs from file that end with `,`,
    - Done in `get_values` for symmetry with surt inputs from command line.
- Data flow is like:
    - Input file lists: `helsinki.fi`, `*.helsinki.fi`
    - `utils.thing_to_surt_host_name` maps into: [`fi,helsinki`, `fi,helsinki,`]
    - `get_values` combines list into a list of LIKE clauses, `(surt_host_name LIKE 'fi,helsinki' OR surt_host_name LIKE 'fi,helsinki,%')`, also handling addition of `%` after `,`.

- ~~Adds tests~~
    - I didnt see any relevant tests in `graph.py` to extend, I guess more tests might be added in v3. 
    - **Q:** Shall I leave like this, or shall I add tests for the entire inputting system? (surt-inputs-to-sql can be tested more easily, without a setup like duckdb part would need.)


### Simple verification for the fix:

Corrects the behavior in #5:

Running only against "CC-MAIN-2021-49" for speed:

- graph.py behavior:
```
$ cat helsinki_fi_and_subdomains.txt
cs.helsinki.fi
*.cs.helsinki.fi

$ cat helsinki_fi_and_subdomains.txt_sum.csv
"crawl","sum_fetch_200"
"CC-MAIN-2021-49",33235

$ cat helsinki_fi_only_subdomains.txt
*.cs.helsinki.fi

$ cat helsinki_fi_only_subdomains.txt_sum.csv 
"crawl","sum_fetch_200"
"CC-MAIN-2021-49",32659
```

- Compared against Athena for verification:
```
SELECT sum(fetch_200), surt_host_name, crawl
FROM cchost_index_testing_v2.cchost_index_testing_v2
WHERE (surt_host_name LIKE 'fi,helsinki,cs' OR surt_host_name LIKE 'fi,helsinki,cs,%') AND url_host_tld = 'fi' AND crawl='CC-MAIN-2021-49'
GROUP BY surt_host_name, crawl
ORDER BY crawl ASC
```

Non-zero fetch-200 rows:
<img width="1635" height="1043" alt="image" src="https://github.com/user-attachments/assets/081a10d4-a8fd-41c4-8c87-da16abaf85c1" />


```